### PR TITLE
Parsing enterprise networks

### DIFF
--- a/iwlist.py
+++ b/iwlist.py
@@ -1,55 +1,90 @@
 import re
 import subprocess
 
-cellNumberRe = re.compile(r"^Cell\s+(?P<cellnumber>.+)\s+-\s+Address:\s(?P<mac>.+)$")
+cellNumberRe = re.compile(
+    r"^Cell\s+(?P<cellnumber>.+)\s+-\s+Address:\s(?P<mac>.+)$")
 regexps = [
     re.compile(r"^ESSID:\"(?P<essid>.*)\"$"),
     re.compile(r"^Protocol:(?P<protocol>.+)$"),
     re.compile(r"^Mode:(?P<mode>.+)$"),
-    re.compile(r"^Frequency:(?P<frequency>[\d.]+) (?P<frequency_units>.+) \(Channel (?P<channel>\d+)\)$"),
+    re.compile(
+        r"^Frequency:(?P<frequency>[\d.]+) (?P<frequency_units>.+) \(Channel (?P<channel>\d+)\)$"),
     re.compile(r"^Encryption key:(?P<encryption>.+)$"),
-    re.compile(r"^Quality=(?P<signal_quality>\d+)/(?P<signal_total>\d+)\s+Signal level=(?P<signal_level_dBm>.+) d.+$"),
+    re.compile(
+        r"^Quality=(?P<signal_quality>\d+)/(?P<signal_total>\d+)\s+Signal level=(?P<signal_level_dBm>.+) d.+$"),
     re.compile(r"^Signal level=(?P<signal_quality>\d+)/(?P<signal_total>\d+).*$"),
 ]
 
 # Detect encryption type
 wpaRe = re.compile(r"IE:\ WPA\ Version\ 1$")
 wpa2Re = re.compile(r"IE:\ IEEE\ 802\.11i/WPA2\ Version\ 1$")
+enterpriseRe = re.compile(r"802\.1x")
 
-# Runs the comnmand to scan the list of networks.
-# Must run as super user.
-# Does not specify a particular device, so will scan all network devices.
+
 def scan(interface='wlan0'):
+    """Runs the comnmand to scan the list of networks.
+
+    Must run as super user.
+    Does not specify a particular device, so will scan all network devices.
+
+    interface : str, optional
+        The network interface to use (the default is 'wlan0', which is the
+                default network interface in major OSs)
+
+    Returns
+    -------
+    str
+        The response from launched command "iwlist scan"
+    """
     cmd = ["iwlist", interface, "scan"]
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
     points = proc.stdout.read().decode('utf-8')
     return points
 
-# Parses the response from the command "iwlist scan"
+
 def parse(content):
+    """Parses the response from the command "iwlist scan"
+
+    Parameters
+    ----------
+    content : str
+        Scan result from `scan` method
+    Returns
+    -------
+    dict
+        Dictionary with all wifi cells with their attributes
+    """
     cells = []
     lines = content.split('\n')
     for line in lines:
         line = line.strip()
         cellNumber = cellNumberRe.search(line)
-        if cellNumber is not None:
+        if cellNumber:
             cells.append(cellNumber.groupdict())
             continue
         wpa = wpaRe.search(line)
-        if wpa is not None :
-            cells[-1].update({'encryption':'wpa'})
+        if wpa:
+            cells[-1].update({'encryption': 'wpa'})
         wpa2 = wpa2Re.search(line)
-        if wpa2 is not None :
-            cells[-1].update({'encryption':'wpa2'}) 
+        if wpa2:
+            cells[-1].update({'encryption': 'wpa2'})
+        enterprise = enterpriseRe.search(line)
+        if enterprise:
+            current_encryption = ''
+            if cells and 'encryption' in cells[-1]:
+                current_encryption = cells[-1].get('encryption')
+            cells[-1].update({'encryption': current_encryption +
+                              '-enterprise'})
         for expression in regexps:
             result = expression.search(line)
-            if result is not None:
-                if 'encryption' in result.groupdict() :
-                    if result.groupdict()['encryption'] == 'on' :
+            if result:
+                if 'encryption' in result.groupdict():
+                    if result.groupdict()['encryption'] == 'on':
                         cells[-1].update({'encryption': 'wep'})
-                    else :
+                    else:
                         cells[-1].update({'encryption': 'off'})
-                else :
+                else:
                     cells[-1].update(result.groupdict())
                 continue
     return cells

--- a/test/enterprise/scan.txt
+++ b/test/enterprise/scan.txt
@@ -1,0 +1,97 @@
+wlan0     Scan completed :
+          Cell 01 - Address: DE:D4:76:EF:CA:A0
+                    Channel:11
+                    Frequency:2.462 GHz (Channel 11)
+                    Quality=70/70  Signal level=-38 dBm
+                    Encryption key:on
+                    ESSID:"wifi-1"
+                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s
+                              24 Mb/s; 36 Mb/s; 54 Mb/s
+                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s
+                    Mode:Master
+                    Extra:tsf=0000000000000000
+                    Extra: Last beacon: 80ms ago
+                    IE: Unknown: 00076169736F796871
+                    IE: Unknown: 010882848B962430486C
+                    IE: Unknown: 03010B
+                    IE: Unknown: 050400030000
+                    IE: Unknown: 0706455320010D14
+                    IE: Unknown: 200100
+                    IE: Unknown: 23021000
+                    IE: Unknown: 2A0100
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : TKIP
+                        Pairwise Ciphers (2) : CCMP TKIP
+                        Authentication Suites (1) : PSK
+                    IE: Unknown: 32040C121860
+                    IE: Unknown: 2D1AAD1917FFFFFF0000000000000000000000000000000000000000
+                    IE: Unknown: 3D160B081100000000000000000000000000000000000000
+                    IE: Unknown: 7F080000000000000040
+                    IE: Unknown: DD0700039301780208
+                    IE: Unknown: DD0E0017F20700010106DCA4CAEF76D5
+                    IE: Unknown: DD090010180200001C0000
+                    IE: WPA Version 1
+                        Group Cipher : TKIP
+                        Pairwise Ciphers (1) : TKIP
+                        Authentication Suites (1) : PSK
+                    IE: Unknown: DD180050F2020101800003A4000027A4000042435E0062322F00
+                    IE: Unknown: 46050200010000
+          Cell 02 - Address: DC:A4:CA:EF:76:D4
+                    Channel:11
+                    Frequency:2.462 GHz (Channel 11)
+                    Quality=70/70  Signal level=-39 dBm
+                    Encryption key:on
+                    ESSID:"wifi2"
+                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 18 Mb/s
+                              24 Mb/s; 36 Mb/s; 54 Mb/s
+                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 48 Mb/s
+                    Mode:Master
+                    Extra:tsf=0000000000000000
+                    Extra: Last beacon: 80ms ago
+                    IE: Unknown: 00056169736F79
+                    IE: Unknown: 010882848B962430486C
+                    IE: Unknown: 03010B
+                    IE: Unknown: 050400030000
+                    IE: Unknown: 0706455320010D14
+                    IE: Unknown: 200100
+                    IE: Unknown: 23021000
+                    IE: Unknown: 2A0100
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : TKIP
+                        Pairwise Ciphers (2) : CCMP TKIP
+                        Authentication Suites (1) : 802.1x
+                    IE: Unknown: 32040C121860
+                    IE: Unknown: 2D1AAD1917FFFFFF0000000000000000000000000000000000000000
+                    IE: Unknown: 3D160B081100000000000000000000000000000000000000
+                    IE: Unknown: 7F080000000000000040
+                    IE: Unknown: DD0B0017F20100010100000007
+                    IE: Unknown: DD0700039301780320
+                    IE: Unknown: DD0E0017F20700010106DCA4CAEF76D5
+                    IE: Unknown: DD090010180200001C0000
+                    IE: WPA Version 1
+                        Group Cipher : TKIP
+                        Pairwise Ciphers (1) : TKIP
+                        Authentication Suites (1) : 802.1x
+                    IE: Unknown: DD180050F2020101800003A4000027A4000042435E0062322F00
+                    IE: Unknown: 46050200010000
+          Cell 03 - Address: A8:40:41:15:4A:B8
+                    Channel:6
+                    Frequency:2.437 GHz (Channel 6)
+                    Quality=28/70  Signal level=-82 dBm
+                    Encryption key:off
+                    ESSID:"wifi3"
+                    Bit Rates:1 Mb/s; 2 Mb/s; 5.5 Mb/s; 11 Mb/s; 6 Mb/s
+                              9 Mb/s; 12 Mb/s; 18 Mb/s
+                    Bit Rates:24 Mb/s; 36 Mb/s; 48 Mb/s; 54 Mb/s
+                    Mode:Master
+                    Extra:tsf=0000000000000000
+                    Extra: Last beacon: 80ms ago
+                    IE: Unknown: 0015454C4543475955502D413834303431313534414238
+                    IE: Unknown: 010882848B960C121824
+                    IE: Unknown: 030106
+                    IE: Unknown: 2A0100
+                    IE: Unknown: 32043048606C
+                    IE: Unknown: 2D1A6C111BFF00000000000000000000000100000000000000000000
+                    IE: Unknown: 3D1606000000000000000000000000000000000000000000
+                    IE: Unknown: 7F080000000000000040
+                    IE: Unknown: DD180050F2020101000003A4000027A4000042435E0062322F00

--- a/test/enterprise/vectors.json
+++ b/test/enterprise/vectors.json
@@ -1,0 +1,41 @@
+[
+    {
+        "signal_quality": "70",
+        "encryption": "wpa",
+        "essid": "wifi-1",
+        "signal_level_dBm": "-38",
+        "mode": "Master",
+        "mac": "DE:D4: 76:EF:CA:A0",
+        "frequency": "2.462",
+        "cellnumber": "01",
+        "signal_total": "70",
+        "channel": "11",
+        "frequency_units": "GHz"
+    },
+    {
+        "signal_quality": "70",
+        "encryption": "wpa-enterprise",
+        "essid": "wifi2",
+        "signal_level_dBm": "-39",
+        "mode": "Master",
+        "mac": "DC:A4:CA:EF: 76:D4",
+        "frequency": "2.462",
+        "cellnumber": "02",
+        "signal_total": "70",
+        "channel": "11",
+        "frequency_units": "GHz"
+    },
+    {
+        "signal_quality": "28",
+        "encryption": "off",
+        "essid": "wifi3",
+        "signal_level_dBm": "-82",
+        "mode": "Master",
+        "mac": "A8: 40: 41: 15: 4A:B8",
+        "frequency": "2.437",
+        "cellnumber": "03",
+        "signal_total": "70",
+        "channel": "6",
+        "frequency_units": "GHz"
+    }
+]


### PR DESCRIPTION
Added parse for enterprise networks.

If 802.11x exists in scan results, is an enterprise network and -enterprise is appended in encryption variable.